### PR TITLE
Add transform utility and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,12 @@ LEFT JOIN bridge_movie_genres AS b ON f.movie_id = b.movie_id
 LEFT JOIN dim_genres AS g ON b.genre_id = g.genre_id
 GROUP BY g.genre_name;
 ```
+
+## 7. Testing
+
+Install the testing dependency and run the test suite with `pytest`:
+
+```bash
+pip install pytest
+pytest
+```

--- a/dags/transform.py
+++ b/dags/transform.py
@@ -1,0 +1,83 @@
+from datetime import datetime
+from typing import Any, Dict, List, Tuple
+
+MovieRecord = Dict[str, Any]
+
+
+def transform_movies(records: List[MovieRecord]) -> Tuple[
+    List[Dict[str, Any]],
+    List[Dict[str, Any]],
+    List[Dict[str, Any]],
+    List[Dict[str, Any]],
+    List[Dict[str, Any]],
+]:
+    """Transform raw TMDB movie records into structured data.
+
+    Returns tuples of lists for fact table entries, unique genres, unique production
+    companies, and bridge tables linking movies to genres and companies. Duplicate
+    genres and companies are removed. Release dates are converted to
+    ``datetime.date`` objects when valid, otherwise ``None``.
+    """
+
+    entries: Dict[int, Dict[str, Any]] = {}
+    genres: Dict[int, str] = {}
+    companies: Dict[int, str] = {}
+    entry_genres_set: set[Tuple[int, int]] = set()
+    entry_companies_set: set[Tuple[int, int]] = set()
+
+    for data in records:
+        if not (data.get("id") and (data.get("title") or data.get("name"))):
+            continue
+
+        entry_id = data["id"]
+        title = data.get("title") or data.get("name")
+        raw_date = data.get("release_date") or data.get("first_air_date")
+        release_date_obj = None
+        if raw_date:
+            try:
+                release_date_obj = datetime.strptime(raw_date, "%Y-%m-%d").date()
+            except (ValueError, TypeError):
+                pass
+
+        entries[entry_id] = {
+            "movie_id": entry_id,
+            "title": title,
+            "release_date": release_date_obj,
+            "revenue": data.get("revenue", 0),
+            "budget": data.get("budget", 0),
+            "popularity": data.get("popularity", 0.0),
+            "vote_average": data.get("vote_average", 0.0),
+            "vote_count": data.get("vote_count", 0),
+            "runtime": data.get("runtime"),
+        }
+
+        for g in data.get("genres", []):
+            genres[g["id"]] = g["name"]
+            entry_genres_set.add((entry_id, g["id"]))
+
+        for c in data.get("production_companies", []):
+            companies[c["id"]] = c["name"]
+            entry_companies_set.add((entry_id, c["id"]))
+
+    entry_genres = [
+        {"movie_id": mid, "genre_id": gid} for (mid, gid) in sorted(entry_genres_set)
+    ]
+    entry_companies = [
+        {"movie_id": mid, "company_id": cid}
+        for (mid, cid) in sorted(entry_companies_set)
+    ]
+
+    return (
+        list(entries.values()),
+        [
+            {"genre_id": gid, "genre_name": name}
+            for gid, name in sorted(genres.items())
+        ],
+        [
+            {"company_id": cid, "company_name": name}
+            for cid, name in sorted(companies.items())
+        ],
+        entry_genres,
+        entry_companies,
+    )
+

--- a/tests/test_etl_transform.py
+++ b/tests/test_etl_transform.py
@@ -1,0 +1,57 @@
+from datetime import date
+
+import os
+import sys
+
+# Ensure project root is on the Python path
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from dags.transform import transform_movies
+
+
+def test_transform_movies_converts_dates_and_filters_duplicates():
+    raw_data = [
+        {
+            "id": 1,
+            "title": "Movie A",
+            "release_date": "2020-01-01",
+            "genres": [
+                {"id": 10, "name": "Action"},
+                {"id": 10, "name": "Action"},
+            ],
+            "production_companies": [
+                {"id": 100, "name": "Company A"},
+                {"id": 100, "name": "Company A"},
+            ],
+        },
+        {
+            "id": 2,
+            "title": "Movie B",
+            "release_date": "invalid-date",
+            "genres": [
+                {"id": 10, "name": "Action"},
+                {"id": 20, "name": "Drama"},
+            ],
+            "production_companies": [
+                {"id": 100, "name": "Company A"},
+                {"id": 200, "name": "Company B"},
+            ],
+        },
+    ]
+
+    entries, genres, companies, _, _ = transform_movies(raw_data)
+
+    assert entries[0]["release_date"] == date(2020, 1, 1)
+    assert entries[1]["release_date"] is None
+
+    assert sorted(genres, key=lambda g: g["genre_id"]) == [
+        {"genre_id": 10, "genre_name": "Action"},
+        {"genre_id": 20, "genre_name": "Drama"},
+    ]
+
+    assert sorted(companies, key=lambda c: c["company_id"]) == [
+        {"company_id": 100, "company_name": "Company A"},
+        {"company_id": 200, "company_name": "Company B"},
+    ]
+
+


### PR DESCRIPTION
## Summary
- extract movie transformation logic into reusable `transform_movies` utility
- cover transformation with pytest checking date parsing and deduplication
- document pytest dependency and how to run tests

## Testing
- `pytest tests/test_etl_transform.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6895d170b0c48330ae179b7aad099e39