### PR TITLE
Add Flink streaming example

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,22 @@ Install the testing dependency and run the test suite with `pytest`:
 pip install pytest
 pytest
 ```
+
+## 8. Streaming with Flink
+
+This project includes a minimal Apache Flink setup for processing streaming
+data. The `docker-compose.yml` file defines **JobManager** and **TaskManager**
+services and mounts Python jobs from the `flink_jobs` directory.
+
+An example job `ratings_stream.py` demonstrates how to process a small stream of
+movie rating events. To submit the job manually:
+
+```bash
+docker-compose exec flink-jobmanager \
+  flink run -py /opt/flink/usrlib/ratings_stream.py
+```
+
+Airflow also contains a DAG (`flink_ratings_job`) that submits the same job using
+`BashOperator`, illustrating how Flink streaming tasks can be orchestrated
+alongside batch ETL workflows.
+

--- a/dags/flink_ratings_job.py
+++ b/dags/flink_ratings_job.py
@@ -1,0 +1,20 @@
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+import pendulum
+
+with DAG(
+    dag_id="flink_ratings_job",
+    start_date=pendulum.datetime(2025, 7, 10, tz="Asia/Jakarta"),
+    schedule=None,
+    catchup=False,
+    tags=["flink", "streaming"],
+    doc_md="""
+    ### Flink Ratings Job
+    Submits a sample PyFlink streaming job to the Flink cluster.
+    """,
+) as dag:
+
+    submit_flink_job = BashOperator(
+        task_id="submit_flink_job",
+        bash_command="flink run -py /opt/flink/usrlib/ratings_stream.py",
+    )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,5 +101,32 @@ services:
     volumes:
       - clickhouse_data:/var/lib/clickhouse
 
+  flink-jobmanager:
+    image: flink:1.17.1-scala_2.12-java11
+    container_name: flink_jobmanager_tmdb
+    ports:
+      - "8081:8081"
+    command: jobmanager
+    environment:
+      - |
+        FLINK_PROPERTIES=
+        jobmanager.rpc.address: flink-jobmanager
+    volumes:
+      - ./flink_jobs:/opt/flink/usrlib
+
+  flink-taskmanager:
+    image: flink:1.17.1-scala_2.12-java11
+    container_name: flink_taskmanager_tmdb
+    command: taskmanager
+    environment:
+      - |
+        FLINK_PROPERTIES=
+        jobmanager.rpc.address: flink-jobmanager
+        taskmanager.numberOfTaskSlots: 2
+    volumes:
+      - ./flink_jobs:/opt/flink/usrlib
+    depends_on:
+      - flink-jobmanager
+
 volumes:
   clickhouse_data:

--- a/flink_jobs/ratings_stream.py
+++ b/flink_jobs/ratings_stream.py
@@ -1,0 +1,25 @@
+from pyflink.datastream import StreamExecutionEnvironment
+from pyflink.common.typeinfo import Types
+
+from flink_jobs.utils import parse_event
+
+
+def main():
+    env = StreamExecutionEnvironment.get_execution_environment()
+    env.set_parallelism(1)
+
+    source = env.from_collection([
+        '{"movie_id": 1, "rating": 8.7}',
+        '{"movie_id": 1, "rating": 9.0}',
+        '{"movie_id": 2, "rating": 7.5}',
+    ])
+
+    parsed = source.map(parse_event, output_type=Types.TUPLE([Types.INT(), Types.FLOAT()]))
+    aggregated = parsed.key_by(lambda x: x[0]).reduce(lambda a, b: (a[0], a[1] + b[1]))
+    aggregated.print()
+
+    env.execute("ratings_stream")
+
+
+if __name__ == "__main__":
+    main()

--- a/flink_jobs/utils.py
+++ b/flink_jobs/utils.py
@@ -1,0 +1,17 @@
+import json
+
+def parse_event(raw: str):
+    """Parse a JSON string from the stream into a tuple.
+
+    Parameters
+    ----------
+    raw: str
+        JSON string containing ``movie_id`` and ``rating`` fields.
+
+    Returns
+    -------
+    tuple[int, float]
+        ``(movie_id, rating)`` where movie_id is an integer and rating is a float.
+    """
+    event = json.loads(raw)
+    return int(event["movie_id"]), float(event["rating"])

--- a/tests/test_flink_parse.py
+++ b/tests/test_flink_parse.py
@@ -1,0 +1,11 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from flink_jobs.utils import parse_event
+
+
+def test_parse_event_parses_json():
+    raw = '{"movie_id": 3, "rating": 9.5}'
+    assert parse_event(raw) == (3, 9.5)


### PR DESCRIPTION
## Summary
- add Flink JobManager and TaskManager services to docker-compose
- include sample PyFlink streaming job and Airflow DAG
- document Flink streaming usage and add unit test for parsing events

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895d43b688c833096704670cff020f0